### PR TITLE
feat: Use hash tagged actions, fix lint issues

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,25 +5,31 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions: {}
+
 jobs:
   go-pipeline:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
-    container:
-      image: golang
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Run CI task from Taskfile
         run: task ci

--- a/.github/workflows/md.yaml
+++ b/.github/workflows/md.yaml
@@ -5,14 +5,18 @@ on:
   push:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   markdownlint-pipeline:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           fetch-depth: 0 # important for git diff comparisons
+          persist-credentials: false
 
     - name: Run Markdownlint
-      uses: open-crypto-broker/.github/actions/markdownlint@main
+      uses: open-crypto-broker/.github/actions/markdownlint@main # nolint # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,9 +16,14 @@ on:
         type: string
         default: "."
 
+permissions: {}
+
 jobs:
   scan:
-    uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main
+    permissions:
+      security-events: write
+      contents: read
+    uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main # nolint # zizmor: ignore[unpinned-uses]
     with:
       scan_directory: ${{ inputs.scan_directory || true }}
       directory_to_scan: ${{ inputs.directory_to_scan || '.' }}

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -7,29 +7,31 @@ on:
         description: 'New version (e.g. 1.3.0)'
         required: true
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   changelog:
     name: Update changelog
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment: DEPLOYMENT
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_SECRET }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Use git-cliff for changelog generation, create git tag, push to repo
-        uses: open-crypto-broker/.github/actions/git-cliff@main
+        uses: open-crypto-broker/.github/actions/git-cliff@main # nolint # zizmor: ignore[unpinned-uses]
         with:
           REF_NAME: ${{ github.ref_name }}
           VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions: {}
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1; next }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --verify-tag -F release-notes.md


### PR DESCRIPTION
## Description
Change actions to hash tagged versions.
Use Go version specified in the go.mod file. With that we have only one point where to set the Go version.
Fix lint issues.
Add new release workflow to automatically create a release after the changelog was generated.
Extract the changes from changelog to the release notes in GitHub release page.

## Type of change
- [ ] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
