### PR TITLE
refactor: Adjust workflow files

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,12 +5,17 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   go-pipeline:
+    name: Go CI Pipeline
     permissions:
-      contents: read
+      contents: read # for checking out code and submodules
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/md.yaml
+++ b/.github/workflows/md.yaml
@@ -1,22 +1,15 @@
 name: Markdownlint
 
 on:
-  pull_request:
   push:
     branches: [ main ]
+  pull_request:
 
 permissions: {}
 
 jobs:
-  markdownlint-pipeline:
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-          fetch-depth: 0 # important for git diff comparisons
-          persist-credentials: false
-
-    - name: Run Markdownlint
-      uses: open-crypto-broker/.github/actions/markdownlint@main # nolint # zizmor: ignore[unpinned-uses]
+  lint:
+    name: Markdownlint
+    permissions:
+      contents: read # for checking out code
+    uses: open-crypto-broker/.github/.github/workflows/markdownlint.yaml@main # nolint # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,10 +20,11 @@ permissions: {}
 
 jobs:
   scan:
+    name: Nightly Security Scan
     permissions:
-      security-events: write
-      contents: read
-      packages: read # required even if scan-image is skipped; GitHub validates all job permissions at parse time
+      contents: read # for checking out code
+      packages: read # required for pulling images from GHCR
+      security-events: write # for uploading SARIF security scan results
     uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main # nolint # zizmor: ignore[unpinned-uses]
     with:
       scan_directory: ${{ inputs.scan_directory || true }}

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -7,20 +7,26 @@ on:
         description: 'New version (e.g. 1.3.0)'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   changelog:
     name: Update changelog
     permissions:
-      contents: write
+      contents: write # for pushing updated changelog and tag to repo
     runs-on: ubuntu-latest
     environment: DEPLOYMENT
+
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Create GitHub app token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_SECRET }}
 
       - name: Checkout repository
@@ -28,9 +34,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Use git-cliff for changelog generation, create git tag, push to repo
         uses: open-crypto-broker/.github/actions/git-cliff@main # nolint # zizmor: ignore[unpinned-uses]
         with:
-          REF_NAME: ${{ github.ref_name }}
-          VERSION: ${{ github.event.inputs.version }}
+          ref_name: ${{ github.ref_name }}
+          version: ${{ github.event.inputs.version }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,14 +5,19 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   github-release:
     name: Create GitHub Release
     permissions:
-      contents: write
+      contents: write # for creating the GitHub release
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -2,12 +2,13 @@ name: Workflow Lint
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
 
 permissions: {}
 
 jobs:
   lint:
+    name: Lint Workflow
     uses: open-crypto-broker/.github/.github/workflows/workflow-lint.yaml@main # nolint # zizmor: ignore[unpinned-uses]
 


### PR DESCRIPTION
## Description
Move the markdownlint workflow into the .github repo and making this just a thin caller.
Pass the github-app-token to the create release workflow to be able to push the updated changelog back to repo.
Fix all zizmor pedantic warnings (concurrency setting, missing names for steps, missing comments for permissions).

## Type of change
- [ ] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [x] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
