### PR TITLE
feat: enable initial connection configuration + add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,72 @@ if err != nil {
 fmt.Printf("Signed certificate: %s\n", responseBody.signedCertificate)
 ```
 
+## Custom Configurations
+
+You can customize the gRPC server and its interceptors (retry mechanism and circuit breaker) using the configuration structures outlined below.
+
+### gRPC Server Configuration
+
+Use the GrpcConfig struct to define the core connectivity parameters for the gRPC server.
+
+```go
+type GrpcConfig struct {
+  ConnMaxRetries int
+}
+```
+
+Example Usage
+
+```go
+grpcConfig := GrpcConfig{ConnMaxRetries: 60}
+
+lib, err := NewLibrary(ctx, grpcConf)
+```
+
+### Interceptor Configuration
+
+The library provides two configurable interceptors to improve resilience: a Retry Mechanism and a Circuit Breaker.
+
+```go
+type RetryConfig struct {
+  MaxAttempts          uint         `yaml:"maxAttempts"`
+  InitialBackoff       string       `yaml:"initialBackoff"`
+  BackoffMultiplier    float64      `yaml:"backoffMultiplier"`
+  RetryableStatusCodes []codes.Code `yaml:"retryableStatusCodes"`
+}
+
+type CircuitConfig struct {
+  Name                string       `yaml:"name"`
+  MaxRequests         uint32       `yaml:"maxRequests"`
+  Interval            string       `yaml:"interval"`
+  Timeout             string       `yaml:"timeout"`
+  ConsecutiveFailures uint32       `yaml:"consecutiveFailures"`
+  FailureStatusCodes  []codes.Code `yaml:"failureStatusCodes"`
+}
+```
+
+Example Usage
+
+```go
+retryConf := interceptor.RetryConfig{
+  MaxAttempts:          5,
+  InitialBackoff:       "500ms",
+  BackoffMultiplier:    2.0,
+  RetryableStatusCodes: []codes.Code{14, 8, 10},
+}
+
+breakerConf := interceptor.CircuitConfig{
+  Name:                "crypto-grpc",
+  MaxRequests:         3,
+  Interval:            "30s",
+  Timeout:             "5s",
+  ConsecutiveFailures: 3,
+  FailureStatusCodes:  []codes.Code{14, 8, 10},
+}
+
+lib, err := NewLibrary(ctx, retryConf, breakerConf)
+```
+
 ## Development
 
 This section covers how to contribute to the project and develop it further.

--- a/lib.go
+++ b/lib.go
@@ -36,15 +36,22 @@ type Library struct {
 	conn         *grpc.ClientConn
 }
 
+type GrpcConfig struct {
+	ConnMaxRetries int
+}
+
 // NewLibrary returns pointer to GrpcLibrary instance.
 // Internally it establishes connection to the gRPC server,
-// configures provided unary interceptors, verifies connectivity,
+// configures provided unary interceptors and grpc server, verifies connectivity,
 // or returns non-nil error if any occures.
 func NewLibrary(ctx context.Context, configs ...any) (*Library, error) {
 	// Create a custom dialer for Unix domain sockets
 	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
 		return net.Dial("unix", defaultSocketPath)
 	}
+
+	// Set default GRPC server configuration
+	grpcConfig := GrpcConfig{ConnMaxRetries: 60}
 
 	// Create default interceptors
 	retry, err := retryInterceptor()
@@ -57,13 +64,15 @@ func NewLibrary(ctx context.Context, configs ...any) (*Library, error) {
 		return nil, err
 	}
 
-	// Apply custom configuration to interceptors
+	// Apply custom configurations
 	for _, conf := range configs {
 		switch t := conf.(type) {
 		case interceptor.RetryConfig:
 			retry, err = interceptor.Retry(t)
 		case interceptor.CircuitConfig:
 			breaker, err = interceptor.CircuitBreaker(t)
+		case GrpcConfig:
+			grpcConfig = t
 		}
 
 		if err != nil {
@@ -90,7 +99,8 @@ func NewLibrary(ctx context.Context, configs ...any) (*Library, error) {
 		conn:         conn,
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, 60*time.Second)
+	duration := time.Duration(grpcConfig.ConnMaxRetries) * time.Second
+	ctxTimeout, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 
 	if err = lib.verifyConnection(ctxTimeout); err != nil {

--- a/lib_test.go
+++ b/lib_test.go
@@ -30,6 +30,8 @@ func TestNewLibrary(t *testing.T) {
 			ctx, cancel := tt.ctxGenerator()
 			defer cancel()
 
+			grpcConf := GrpcConfig{ConnMaxRetries: 60}
+
 			retryConf := interceptor.RetryConfig{
 				MaxAttempts:          5,
 				InitialBackoff:       "500ms",
@@ -46,7 +48,7 @@ func TestNewLibrary(t *testing.T) {
 				FailureStatusCodes:  []codes.Code{14, 8, 10},
 			}
 
-			_, err := NewLibrary(ctx, retryConf, breakerConf)
+			_, err := NewLibrary(ctx, grpcConf, retryConf, breakerConf)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewLibrary() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Description
Enable user to configure initial connection retry.
Document how users can apply custom configuration to gRPC server and interceptors.

#308

## Type of change
- [ ] Bug fix
- [x ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
