### PR TITLE
fix: Adjust gitsubmodule path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "gitsubmodule" # zizmor: ignore[dependabot-cooldown]
-    directory: "/protobuf"
+    # Look for the .gitmodules file in the root of the repository to find submodules.
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Description
Look for the .gitmodules file in the repository root.

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
